### PR TITLE
BETL-702 Add slack example with branching of airflow tasks

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
       - 1444:1433
 
   airflow:
-    image: laudio/airflow-mssql:1.0.4
+    image: laudio/airflow-mssql:1.0.5
     container_name: airflow
     restart: always
     depends_on:


### PR DESCRIPTION
* Add slack example with branching of airflow tasks
* Branching for slack success and failure messages

**Depends on:** laudio/docker-airflow-mssql#2
**Note:** Update `docker-composer.yml` file to use latest docker image for `airflow` service.